### PR TITLE
use @rails/request.js and add sortable-ended event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stimulus-sortable",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A Stimulus controller to reorder lists with drag-and-drop.",
   "repository": "git@github.com:stimulus-components/stimulus-sortable.git",
   "author": "Guillaume Briday <guillaumebriday@gmail.com>",
@@ -33,7 +33,7 @@
     "version": "yarn build"
   },
   "dependencies": {
-    "@rails/ujs": "^6.0.3-4",
+    "@rails/request.js": "^0.0.5",
     "sortablejs": "^1.12.0",
     "stimulus": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { Controller } from 'stimulus'
 import Sortable from 'sortablejs'
-import Rails from '@rails/ujs'
+import { patch } from '@rails/request.js'
 
 export default class extends Controller {
   static values = {
@@ -26,8 +26,8 @@ export default class extends Controller {
     this.sortable = undefined
   }
 
-  end ({ item, newIndex }) {
-    if (!item.dataset.sortableUpdateUrl || !window._rails_loaded) return
+  async end ({ item, newIndex }) {
+    if (!item.dataset.sortableUpdateUrl) return
 
     const resourceName = this.resourceNameValue
     const paramName = this.paramNameValue || 'position'
@@ -36,11 +36,14 @@ export default class extends Controller {
     const data = new FormData()
     data.append(param, newIndex + 1)
 
-    Rails.ajax({
-      url: item.dataset.sortableUpdateUrl,
-      type: 'PATCH',
-      data
-    })
+    await patch(item.dataset.sortableUpdateUrl, { body: data })
+
+    this.ended()
+  }
+
+  ended () {
+    const event = new CustomEvent('sortable-ended')
+    window.dispatchEvent(event)
   }
 
   get options () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1628,10 +1628,10 @@
   resolved "https://registry.yarnpkg.com/@pika/types/-/types-0.9.2.tgz#60ad16afe1293878232e28937d9007340c59ff7c"
   integrity sha512-AzZTkHtM0A67+xMVhmSeJDteSMS+RfXGuM+/oVbo1PGD19ic7fuimv5b0TW8dKoZuxpVxiwVAai+sFRSNmfI3g==
 
-"@rails/ujs@^6.0.3-4":
-  version "6.0.3-4"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.3-4.tgz#8dafc84178080f9c4f21076953ea1d0dc0bfe0fc"
-  integrity sha512-pNEEndJYNMCYEZG79MkoMc40AYKBfm0md8pawJ/SUu/1aIhToJcKu+9hHT/7WMLudsakOgC/C8KKFuZOs4QTgw==
+"@rails/request.js@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.5.tgz#5ea896085f1c82bacca0e32aa918c8cd003a3d30"
+  integrity sha512-EDw3d5oCSPFn/os7C41+61urT5J5n+bMXK2NTQVhJI8VCPAIVbvFGjZIQI0a9zJ9KuaWKHM6IjXTRakKemlzoA==
 
 "@rollup/plugin-alias@^3.0.1":
   version "3.1.1"


### PR DESCRIPTION
1. Add sortable-ended CustomEvent that users can do something after the ajax finished
2. use @rails/request.js which is a wrapper of fetch API, so we can use async/await

I think if the users are not listening to "ajax:success" event which came from Rails.ajax, they won't feel any difference after replacing the Rails-ujs by Request.js

How do you think?