### PR TITLE
Allow `responseKind` to be configured for turbo-stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adding `responseKind` option.
+
 ## [3.1.0] - 2021-10-12
 
 ### Chore

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export default class extends Controller {
   animationValue: number
   resourceNameValue: string
   paramNameValue: string
+  responseKindValue: string
   sortable: Sortable
   handleValue: string
   // @ts-ignore
@@ -16,6 +17,10 @@ export default class extends Controller {
     paramName: {
       type: String,
       default: 'position'
+    },
+    responseKind: {
+      type: String,
+      default: 'html'
     },
     animation: Number,
     handle: String
@@ -45,7 +50,7 @@ export default class extends Controller {
     const data = new FormData()
     data.append(param, newIndex + 1)
 
-    await patch(item.dataset.sortableUpdateUrl, { body: data })
+    await patch(item.dataset.sortableUpdateUrl, { body: data, responseKind: this.responseKindValue })
   }
 
   get options (): Sortable.Options {


### PR DESCRIPTION
By default, `@rails/request.js` uses `responseKind: "html"` when
handling a request:

https://github.com/rails/requestjs-rails/blob/fb45ff58961dd13e1083ca7227c0eb51a41c7b20/app/assets/javascripts/requestjs.js#L213-L215

In order to override this and allow `turbo-stream` to be specified, this
adds a configuration option.

You can specify the response-kind-value like this:

```
  ul data-controller='sortable' data-sortable-response-kind-value='turbo-stream'
```

Note: This was very much inspired by the approach taken in #4 - if there is any additional context I should be taking care of, please let me know.