### PR TITLE
Return response after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Return the response object from `onUpdate`
+
 ## [4.1.0] - 2022-12-25
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export default class extends Controller {
     const data = new FormData()
     data.append(param, newIndex + 1)
 
-    await patch(item.dataset.sortableUpdateUrl, { body: data, responseKind: this.responseKindValue })
+    return await patch(item.dataset.sortableUpdateUrl, { body: data, responseKind: this.responseKindValue })
   }
 
   get options (): Sortable.Options {


### PR DESCRIPTION
Right now it's impossible to do anything with the response from onUpdate() when subclassing. I'd like to be able to examine the response object and take further actions depending on the result.

To make this possible, I've returned the response, which I think should make it possible to use it if needed.