### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@hotwired/stimulus": "^3.2.1",
-    "@rails/request.js": "^0.0.8",
+    "@rails/request.js": "^0.0.9",
     "@types/sortablejs": "^1.15.1",
     "autoprefixer": "^10.4.14",
     "np": "^7.6.2",


### PR DESCRIPTION
Bumps rails/request.js version in order to stop warnings with the latest version.